### PR TITLE
Optional yaml source returns empty dict if path not found.

### DIFF
--- a/dnry/config/yaml/source.py
+++ b/dnry/config/yaml/source.py
@@ -17,6 +17,9 @@ class YamlSource(IConfigSource):
             paths = ",".join(self.__paths)
             raise RuntimeError(f"Configuration Error: None of these paths could be found: {paths}")
 
+        elif path is None and not self.__required:
+            return dict()
+
         with open(path, 'r') as f:
             return yaml.load(f, Loader=self.__loader) or dict()
 

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -9,7 +9,7 @@ from dnry.config.yaml import YamlSource
 class TestBugs(unittest.TestCase):
 
     def test_empty_yaml_file(self):
-        temp_file = f"./${uuid4()}.yaml"
+        temp_file = f"./{uuid4()}.yaml"
         with open(temp_file, 'w') as fd:
             fd.write('\n')
         try:
@@ -21,3 +21,10 @@ class TestBugs(unittest.TestCase):
 
         finally:
             os.remove(temp_file)
+
+    def test_optional_flag(self):
+        fact = ConfigFactory()
+        fact.add_source(YamlSource(f"./{uuid4()}", required=False))
+        conf = fact.build()
+        none_val = conf.get("no:key")
+        self.assertIsNone(none_val)


### PR DESCRIPTION
Added branch in yaml source that returns an empty dict if the path does not exist and the source is optional. Fixes #1